### PR TITLE
Add a context menu

### DIFF
--- a/src/context-menu.js
+++ b/src/context-menu.js
@@ -1,0 +1,21 @@
+// Checking if context menu is enabled in options
+chrome.storage.sync.get({turnOffContextMenu: false}, results => {
+    if (results.turnOffContextMenu) {
+        return;
+    }
+    // Set up onclick listener for context menu
+    chrome.contextMenus.onClicked.addListener(tab => {
+        chrome.tabs.executeScript({file: 'script.js', allFrames: true});
+    });
+
+    // Set up context menu at install time
+    chrome.runtime.onInstalled.addListener(function () {
+        // Create context menu for `page` and `video` type
+        let contexts = ["page", "video"];
+        for (let i = 0; i < contexts.length; i++) {
+            let context = contexts[i];
+            let title = "Picture-in-picture";
+            chrome.contextMenus.create({"title": title, "contexts": [context], "id": "context" + context});
+        }
+    });
+});

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -7,7 +7,7 @@
   },
   "background": {
     "persistent": false,
-    "scripts": ["background.js"]
+    "scripts": ["background.js", "context-menu.js"]
   },
   "browser_action": {
     "default_icon": {
@@ -32,7 +32,8 @@
   "content_security_policy": "script-src 'self' https://ssl.google-analytics.com; object-src 'self'",
   "permissions": [
     "<all_urls>",
-    "storage"
+    "storage",
+    "contextMenus"
   ],
   "minimum_chrome_version": "69.0.3483.0",
   "manifest_version": 2

--- a/src/options.html
+++ b/src/options.html
@@ -3,10 +3,15 @@
 <head>
 </head>
 <body>
-  <label>
+<label>
     <input type="checkbox" id="optOutAnalytics">
     <span>Opt-out of Google Analytics</span>
-  </label>
-  <script src="options.js"></script>
+</label>
+<br>
+<label>
+    <input type="checkbox" id="turnOffContextMenu">
+    <span>Turn off context menu option</span>
+</label>
+<script src="options.js"></script>
 </body>
 </html>

--- a/src/options.html
+++ b/src/options.html
@@ -10,7 +10,7 @@
 <br>
 <label>
     <input type="checkbox" id="turnOffContextMenu">
-    <span>Turn off context menu option</span>
+    <span>Turn off context menu</span>
 </label>
 <script src="options.js"></script>
 </body>

--- a/src/options.js
+++ b/src/options.js
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-chrome.storage.sync.get({ optOutAnalytics: false }, results => {
+chrome.storage.sync.get({ optOutAnalytics: false, turnOffContextMenu: false}, results => {
   const optOutAnalyticsCheckbox = document.querySelector('#optOutAnalytics');
 
   optOutAnalyticsCheckbox.checked = results.optOutAnalytics;
@@ -20,7 +20,21 @@ chrome.storage.sync.get({ optOutAnalytics: false }, results => {
     chrome.storage.sync.set({
       optOutAnalytics: optOutAnalyticsCheckbox.checked
     }, _ => {
-      // Reload extension to make opt-out change immediate. 
+      // Reload extension to make opt-out change immediate.
+      chrome.runtime.reload();
+      window.close();
+    });
+  };
+
+  // Settings for turn off context menu
+  const turnOffContextMenuCheckbox = document.querySelector('#turnOffContextMenu');
+
+  turnOffContextMenuCheckbox.checked = results.turnOffContextMenu;
+  turnOffContextMenuCheckbox.onchange = _ => {
+    chrome.storage.sync.set({
+      turnOffContextMenu: turnOffContextMenuCheckbox.checked
+    }, _ => {
+      // Reload extension to make opt-out change immediate.
       chrome.runtime.reload();
       window.close();
     });


### PR DESCRIPTION
Hi,

I understand this issue has been raised in one of the previous [pull requests](https://github.com/GoogleChromeLabs/picture-in-picture-chrome-extension/pull/22#issue-278057200).

However, I think adding a context menu would be very useful, for example:

- **UC1**: Given a user has no, or difficult access to a keyboard (using a wireless mouse, remote projecting, etc), the user can enable PiP mode simply through the context menu.
- **UC2**: Given a user with conflicting keyboard shortcut, the user do not need to re-assign a new shortcut, and can enable PiP mode simply through the context menu.

Moreover, I have also added an option to disable the context menu for users that do not want this feature, the option can be found under Extension options.

Please consider adding this feature, thanks.
